### PR TITLE
no longer crashes on cannot update deleted, logs it and continues

### DIFF
--- a/src/OpenFTTH.AddressImport.Dawa/AddressChangesImportDawa.cs
+++ b/src/OpenFTTH.AddressImport.Dawa/AddressChangesImportDawa.cs
@@ -662,7 +662,8 @@ official accessAddressId: '{AccessAddressId}'.",
                 {
                     // There will always only be a single error.
                     var error = (UnitAddressError)updateResult.Errors.First();
-                    if (error.Code == UnitAddressErrorCode.NO_CHANGES)
+                    if (error.Code == UnitAddressErrorCode.NO_CHANGES ||
+                        error.Code == UnitAddressErrorCode.CANNOT_UPDATE_DELETED)
                     {
                         _logger.LogInformation(
                             "{ExternalId}: {ErrorMessage}",


### PR DESCRIPTION
Sometimes we might receive updates on something that has been deleted, it would be dangerous to save the event, but this commit changes it so we do not save it, we just crash and continues.